### PR TITLE
try_dequeue should return early if queue is empty

### DIFF
--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -168,6 +168,10 @@ public:
 		fence(memory_order_acquire);
 
 		Block* frontBlock_ = frontBlock.load();
+		if (frontBlock_ == nullptr) {
+			return false;
+		}
+
 		size_t blockTail = frontBlock_->tail.load();
 		size_t blockFront = frontBlock_->front.load();
 		fence(memory_order_acquire);


### PR DESCRIPTION
I'm not 100% sure that this is the correct behavior here, however I
noticed segfaults in my code when calling try_dequeue from a
newly-initialized queue. In such cases, frontBlock.load() will at
least return nullptr, and attempting to call any methods on such a
pointer will result in segfaults.
