### PR TITLE
Include <new> for std::bad_alloc

### DIFF
--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <cassert>
 #include <stdexcept>
+#include <new>
 #include <cstdint>
 #include <cstdlib>		// For malloc/free/abort & size_t
 #if __cplusplus > 199711L


### PR DESCRIPTION
Without it compilation failed on OS X using Apple LLVM version
7.3.0 (clang-703.0.29)