### PR TITLE
Modified test makefiles to also support Mac OS X

### DIFF
--- a/tests/stabtest/makefile
+++ b/tests/stabtest/makefile
@@ -1,18 +1,24 @@
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
 	PLATFORM_OPTS=-static
-	PLATFORM_LD_OPTS=
+	PLATFORM_LD_OPTS=-Wl,--no-as-needed
 else
-	EXT=
-	PLATFORM_OPTS=
-	PLATFORM_LD_OPTS=-lrt
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=
+	else
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=-lrt -Wl,--no-as-needed
+	endif
 endif
-
 
 default: stabtest$(EXT)
 
 stabtest$(EXT): stabtest.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS) -Wl,--no-as-needed
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: stabtest$(EXT)
 	./stabtest$(EXT)

--- a/tests/unittests/makefile
+++ b/tests/unittests/makefile
@@ -1,18 +1,25 @@
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
 	PLATFORM_OPTS=-static
-	PLATFORM_LD_OPTS=
+	PLATFORM_LD_OPTS=-Wl,--no-as-needed
 else
-	EXT=
-	PLATFORM_OPTS=
-	PLATFORM_LD_OPTS=-lrt
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=
+	else
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=-lrt -Wl,--no-as-needed
+	endif
 endif
 
 
 default: unittests$(EXT)
 
 unittests$(EXT): unittests.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp minitest.h makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS) -Wl,--no-as-needed
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: unittests$(EXT)
 	./unittests$(EXT)


### PR DESCRIPTION
Hi Cameron,

    I'm currently evaluating your readerwriterqueue - pretty nice implementation! I am looking to replace the Boost spsc queue in the LockFree library to avoid a Boost dependency. I build on Mac (though deploy on Linux) and had some minor issues compiling. I added some minor changes to your testing makefiles to properly build with clang on Mac.

   I added these changes based on information I pulled from:
http://stackoverflow.com/questions/714100/os-detecting-makefile

Regards,
Ryan