### PR TITLE
Use push/pop for temporary disabled warning

### DIFF
--- a/atomicops.h
+++ b/atomicops.h
@@ -229,6 +229,7 @@ class weak_atomic
 public:
 	weak_atomic() { }
 #ifdef AE_VCPP
+#pragma warning(push)
 #pragma warning(disable: 4100)		// Get rid of (erroneous) 'unreferenced formal parameter' warning
 #endif
 	template<typename U> weak_atomic(U&& x) : value(std::forward<U>(x)) {  }
@@ -239,7 +240,7 @@ public:
 	weak_atomic(weak_atomic const& other) : value(other.value) {  }
 	weak_atomic(weak_atomic&& other) : value(std::move(other.value)) {  }
 #ifdef AE_VCPP
-#pragma warning(default: 4100)
+#pragma warning(pop)
 #endif
 
 	AE_FORCEINLINE operator T() const { return load(); }


### PR DESCRIPTION
Pushing and popping when disabling warning 4100 will return the setting to the state before disabling, which may be different than the compiler default setting.