### PR TITLE
Add emplace() and try_emplace() APIs.

### DIFF
--- a/atomicops.h
+++ b/atomicops.h
@@ -83,7 +83,7 @@ enum memory_order {
 
 }    // end namespace moodycamel
 
-#if (defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))) || defined(AE_ICC)
+#if (defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))) || defined(__INTEL_COMPILER < 1600)
 // VS2010 and ICC13 don't support std::atomic_*_fence, implement our own fences
 
 #include <intrin.h>

--- a/atomicops.h
+++ b/atomicops.h
@@ -83,7 +83,7 @@ enum memory_order {
 
 }    // end namespace moodycamel
 
-#if (defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))) || defined(__INTEL_COMPILER < 1600)
+#if (defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))) || (defined(AE_ICC) && __INTEL_COMPILER < 1600)
 // VS2010 and ICC13 don't support std::atomic_*_fence, implement our own fences
 
 #include <intrin.h>

--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -40,8 +40,10 @@
 #endif
 #endif
 
-#if !defined _MSC_VER || _MSC_VER >= 1800 // variadic templates: either a non-MS compiler or VS >= 2013
+#ifndef MOODYCAMEL_HAS_EMPLACE
+#if !defined(_MSC_VER) || _MSC_VER >= 1800 // variadic templates: either a non-MS compiler or VS >= 2013
 #define MOODYCAMEL_HAS_EMPLACE    1
+#endif
 #endif
 
 #ifdef AE_VCPP
@@ -227,7 +229,7 @@ public:
 	}
 
 #if MOODYCAMEL_HAS_EMPLACE
-	// Like try_enqueue() but emplace semantics (ie construct-in-place)
+	// Like try_enqueue() but with emplace semantics (i.e. construct-in-place).
 	template<typename... Args>
 	AE_FORCEINLINE bool try_emplace(Args&&... args)
 	{
@@ -252,7 +254,7 @@ public:
 	}
 
 #if MOODYCAMEL_HAS_EMPLACE
-	// Like enqueue() but emplace semantics (ie construct-in-place)
+	// Like enqueue() but with emplace semantics (i.e. construct-in-place).
 	template<typename... Args>
 	AE_FORCEINLINE bool emplace(Args&&... args)
 	{

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -47,7 +47,7 @@ private:
 class UniquePtrWrapper
 {
 public:
-    UniquePtrWrapper() = default;
+	UniquePtrWrapper() = default;
 	UniquePtrWrapper(std::unique_ptr<int> p) : m_p(std::move(p)) {}
 	int get_value() const { return *m_p; }
 	std::unique_ptr<int>& get_ptr() { return m_p; }
@@ -76,8 +76,8 @@ public:
 		REGISTER_TEST(vector);
 #if MOODYCAMEL_HAS_EMPLACE
 		REGISTER_TEST(emplace);
-		REGISTER_TEST(try_enqueue_bad);
-		REGISTER_TEST(try_emplace);
+		REGISTER_TEST(try_enqueue_fail_workaround);
+		REGISTER_TEST(try_emplace_fail);
 #endif
 	}
 	
@@ -573,7 +573,7 @@ public:
 	}
 
 	// This is what you have to do to try_enqueue() a movable type, and demonstrates why try_emplace() is useful
-	bool try_enqueue_bad()
+	bool try_enqueue_fail_workaround()
 	{
 		ReaderWriterQueue<UniquePtrWrapper> q(0);
 		{
@@ -597,7 +597,7 @@ public:
 		return true;
 	}
 
-	bool try_emplace()
+	bool try_emplace_fail()
 	{
 		ReaderWriterQueue<UniquePtrWrapper> q(0);
 		std::unique_ptr<int> p { new int(123) };

--- a/tests/unittests/unittests.cpp
+++ b/tests/unittests/unittests.cpp
@@ -73,9 +73,11 @@ public:
 		REGISTER_TEST(threaded);
 		REGISTER_TEST(blocking);
 		REGISTER_TEST(vector);
+#if MOODYCAMEL_HAS_EMPLACE
 		REGISTER_TEST(emplace);
 		REGISTER_TEST(try_enqueue_bad);
 		REGISTER_TEST(try_emplace);
+#endif
 	}
 	
 	bool create_empty_queue()
@@ -555,6 +557,7 @@ public:
 		return true;
 	}
 
+#if MOODYCAMEL_HAS_EMPLACE
 	bool emplace()
 	{
 		ReaderWriterQueue<Wrapper> q(100);
@@ -603,6 +606,7 @@ public:
 
 		return true;
 	}
+#endif
 };
 
 


### PR DESCRIPTION
Change-Id: I9236fdc4b9c143afd81fed509c8d6d4803878e5a

Add C++11 style construct-in-place functionality. This is particularly useful for try_emplace(), which may fail if queue is full, as it avoid unnecessary work, and invoking move on the params.

See also:
https://github.com/cameron314/readerwriterqueue/issues/54
http://en.cppreference.com/w/cpp/container/queue/emplace