### PR TITLE
Fix type precision warning in Xcode 9

### DIFF
--- a/atomicops.h
+++ b/atomicops.h
@@ -450,7 +450,7 @@ namespace moodycamel
 			bool timed_wait(std::int64_t timeout_usecs)
 			{
 				mach_timespec_t ts;
-				ts.tv_sec = timeout_usecs / 1000000;
+				ts.tv_sec = static_cast<unsigned int>(timeout_usecs / 1000000);
 				ts.tv_nsec = (timeout_usecs % 1000000) * 1000;
 
 				// added in OSX 10.10: https://developer.apple.com/library/prerelease/mac/documentation/General/Reference/APIDiffsMacOSX10_10SeedDiff/modules/Darwin.html


### PR DESCRIPTION
Nothing more than it says in the title. Xcode 9 was (rightfully) complaining about the `std::int64_t` data being downcast to an unsigned int (the type of the `tv_sec` field), so I silenced it with a static cast.

This is unlikely to cause issues since the usec-scale time is being divided by 1000000 to convert to sec.