### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,16 @@ about lock-free programming.
 [benchmarks]: http://moodycamel.com/blog/2013/a-fast-lock-free-queue-for-c++#benchmarks
 [gcc46bug]: http://stackoverflow.com/questions/16429669/stdatomic-thread-fence-has-undefined-reference
 [mpmc]: https://github.com/cameron314/concurrentqueue
+
+
+## Building readerwriterqueue - Using vcpkg
+
+You can download and install readerwriterqueue using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install readerwriterqueue
+
+The readerwriterqueue port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
Readerwriterqueue is available as a port in vcpkg, a C++ library manager that simplifies installation for readerwriterqueue and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build readerwriterqueue, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.