### PR TITLE
Add support for installation via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.9)
+project(readerwriterqueue VERSION 1.0.0)
+
+include(GNUInstallDirs)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+install(FILES atomicops.h readerwriterqueue.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,5 @@ include(GNUInstallDirs)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
-install(FILES atomicops.h readerwriterqueue.h
+install(FILES atomicops.h readerwriterqueue.h LICENSE.md
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -90,7 +90,22 @@ means care must be taken to only call `wait_dequeue` if you're sure another elem
 will come along eventually, or if the queue has a static lifetime. This is because
 destroying the queue while a thread is waiting on it will invoke undefined behaviour.
 
-    
+## CMake installation
+As an alternative to including the source files in your project directly,
+you can use CMake to install the library in your system's include directory:
+
+```
+mkdir build
+cd build
+cmake ..
+make install
+```
+
+Then, you can include it from your source code:
+```
+#include <readerwriterqueue/readerwriterqueue.h>
+```
+
 ## Disclaimers
 
 The queue should only be used on platforms where aligned integer and pointer access is atomic; fortunately, that


### PR DESCRIPTION
I personally don't like including the source files in my project directly, especially when I use the library across multiple projects. Therefore, I added a simple CMake script that installs the library into the global headers directory.