### PR TITLE
Pad out ReaderWriterQueue to a whole cache line

### DIFF
--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -58,7 +58,7 @@
 namespace moodycamel {
 
 template<typename T, size_t MAX_BLOCK_SIZE = 512>
-class ReaderWriterQueue
+class AE_ALIGN(MOODYCAMEL_CACHE_LINE_SIZE) ReaderWriterQueue
 {
 	// Design: Based on a queue-of-queues. The low-level queues are just
 	// circular buffers with front and tail indices indicating where the


### PR DESCRIPTION
While investigating some odd performance, I found a case where a lock also
happened to occupy the same cache line as the tailBlock which was leading to
false sharing. Padding out the ReaderWriterQueue prevents this from accidently
happening.

I laso moved dequeuing into the particular cache line that it will first access
in a dequeue operation.