### PR TITLE
Fix warnings about implicit conversion changes signedness

### DIFF
--- a/atomicops.h
+++ b/atomicops.h
@@ -662,10 +662,10 @@ namespace moodycamel
 		        }
 		    }
 		    
-		    size_t availableApprox() const AE_NO_TSAN
+		    std::size_t availableApprox() const AE_NO_TSAN
 		    {
 		    	ssize_t count = m_count.load();
-		    	return count > 0 ? static_cast<size_t>(count) : 0;
+		    	return count > 0 ? static_cast<std::size_t>(count) : 0;
 		    }
 		};
 	}	// end namespace spsc_sema

--- a/atomicops.h
+++ b/atomicops.h
@@ -662,10 +662,10 @@ namespace moodycamel
 		        }
 		    }
 		    
-		    ssize_t availableApprox() const AE_NO_TSAN
+		    size_t availableApprox() const AE_NO_TSAN
 		    {
 		    	ssize_t count = m_count.load();
-		    	return count > 0 ? count : 0;
+		    	return count > 0 ? static_cast<size_t>(count) : 0;
 		    }
 		};
 	}	// end namespace spsc_sema

--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -698,7 +698,7 @@ private:
 
 		// size must be a power of two (and greater than 0)
 		AE_NO_TSAN Block(size_t const& _size, char* _rawThis, char* _data)
-			: front(0), localTail(0), tail(0), localFront(0), next(nullptr), data(_data), sizeMask(_size - 1), rawThis(_rawThis)
+			: front(0UL), localTail(0), tail(0UL), localFront(0), next(nullptr), data(_data), sizeMask(_size - 1), rawThis(_rawThis)
 		{
 		}
 

--- a/tests/stabtest/makefile
+++ b/tests/stabtest/makefile
@@ -18,7 +18,7 @@ endif
 default: stabtest$(EXT)
 
 stabtest$(EXT): stabtest.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Werror -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: stabtest$(EXT)
 	./stabtest$(EXT)

--- a/tests/stabtest/makefile
+++ b/tests/stabtest/makefile
@@ -18,7 +18,7 @@ endif
 default: stabtest$(EXT)
 
 stabtest$(EXT): stabtest.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Werror -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: stabtest$(EXT)
 	./stabtest$(EXT)

--- a/tests/unittests/makefile
+++ b/tests/unittests/makefile
@@ -21,7 +21,7 @@ endif
 default: unittests$(EXT)
 
 unittests$(EXT): unittests.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp minitest.h makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Werror -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: unittests$(EXT)
 	./unittests$(EXT)

--- a/tests/unittests/makefile
+++ b/tests/unittests/makefile
@@ -21,7 +21,7 @@ endif
 default: unittests$(EXT)
 
 unittests$(EXT): unittests.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp minitest.h makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Werror -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
 
 run: unittests$(EXT)
 	./unittests$(EXT)


### PR DESCRIPTION
Using the g++ options `-Werror -Wsign-conversion`, it generates errors like **error: implicit conversion changes signedness**.

```
$ g++  -std=c++11 -Werror -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests -pthread
In file included from unittests.cpp:12:
./../../readerwriterqueue.h:935:16: error: implicit conversion changes signedness: 'moodycamel::spsc_sema::LightweightSemaphore::ssize_t' (aka 'long') to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                return sema->availableApprox();
                ~~~~~~ ~~~~~~^~~~~~~~~~~~~~~~~
unittests.cpp:493:21: note: in instantiation of member function 'moodycamel::BlockingReaderWriterQueue<int, 512>::size_approx' requested here
                        ASSERT_OR_FAIL(q.size_approx() == 0);
                                         ^
In file included from unittests.cpp:12:
./../../readerwriterqueue.h:935:16: error: implicit conversion changes signedness: 'moodycamel::spsc_sema::LightweightSemaphore::ssize_t' (aka 'long') to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                return sema->availableApprox();
                ~~~~~~ ~~~~~~^~~~~~~~~~~~~~~~~
unittests.cpp:582:21: note: in instantiation of member function 'moodycamel::BlockingReaderWriterQueue<UniquePtrWrapper, 512>::size_approx' requested here
                        ASSERT_OR_FAIL(q.size_approx() == 0);
                                         ^
2 errors generated.
make: *** [unittests] Error 1
```

Here is a small fix.