### PR TITLE
Don't destruct element after moving in BlockingReaderWriterQueue's inner_dequeue(..)

### DIFF
--- a/readerwritercircularbuffer.h
+++ b/readerwritercircularbuffer.h
@@ -261,7 +261,6 @@ private:
 		std::size_t i = nextItem++;
 		T& element = reinterpret_cast<T*>(data)[i & mask];
 		item = std::move(element);
-		element.~T();
 		slots->signal();
 	}
 


### PR DESCRIPTION
Clang's static analyzer warns that the destructor should not be called on the object that's had its content moved out.

![2021-02-12_19-44](https://user-images.githubusercontent.com/1557255/107856165-45212e80-6ddb-11eb-9277-addf2d3483e5.png)

Given this warning was coming from clang-11, I opted to install clang 12 and 13 to see if it was possibly a false-positive (and fixed in newer releases).  This isn't the case and all three versions of clang's static analyzer flag this.

This appears to be a valid issue, given the `element` object should be left in a well-defined state even after its contents have been `std::moved` out.

For example, the `element` object could just as easily have more content moved back into it; or it could allocate new content. Calling the destructor on it closes that door for good though, and doesn't leave `element` in  a workable state.

This logic is also confirmed in [the last paragraph here](https://www.internalpointers.com/post/c-rvalue-references-and-move-semantics-beginners):

---
**A typical move constructor:**

``` c++
Holder(Holder&& other) // <-- rvalue reference in input
{
    m_data = other.m_data;   // (1)
    m_size = other.m_size;
    other.m_data = nullptr;  // (2)
    other.m_size = 0;
}
```

It takes in input an rvalue reference to another Holder object. This is the key part: being an rvalue reference, we can modify it.

So let's steal its data first (1), then set it to null (2). No deep copies here, we have just moved resources around!

It's important to set the rvalue reference data to some valid state (2) to prevent it from being accidentally deleted when the temporary object dies: our Holder destructor calls delete[] m_data, remember?

In general, for reasons that will become more clear in a few paragraphs, it's a good idea to always leave the objects being stolen from in some well-defined state.

---