### PR TITLE
Haiku

### DIFF
--- a/tests/stabtest/makefile
+++ b/tests/stabtest/makefile
@@ -1,24 +1,28 @@
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
 	PLATFORM_OPTS=-static
-	PLATFORM_LD_OPTS=-Wl,--no-as-needed
+	PLATFORM_LD_OPTS=-pthread -Wl,--no-as-needed
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		EXT=
 		PLATFORM_OPTS=
-		PLATFORM_LD_OPTS=
+		PLATFORM_LD_OPTS=-pthread
+	else ifeq ($(UNAME_S),Haiku)
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=-Wl,--no-as-needed
 	else
 		EXT=
 		PLATFORM_OPTS=
-		PLATFORM_LD_OPTS=-lrt -Wl,--no-as-needed
+		PLATFORM_LD_OPTS=-pthread -lrt -Wl,--no-as-needed
 	endif
 endif
 
 default: stabtest$(EXT)
 
 stabtest$(EXT): stabtest.cpp ../../readerwriterqueue.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 stabtest.cpp ../common/simplethread.cpp -o stabtest$(EXT)  $(PLATFORM_LD_OPTS)
 
 run: stabtest$(EXT)
 	./stabtest$(EXT)

--- a/tests/unittests/makefile
+++ b/tests/unittests/makefile
@@ -3,17 +3,21 @@
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
 	PLATFORM_OPTS=-static
-	PLATFORM_LD_OPTS=-Wl,--no-as-needed
+	PLATFORM_LD_OPTS=-pthread -Wl,--no-as-needed
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		EXT=
 		PLATFORM_OPTS=
-		PLATFORM_LD_OPTS=
+		PLATFORM_LD_OPTS=-pthread
+	else ifeq ($(UNAME_S),Haiku)
+		EXT=
+		PLATFORM_OPTS=
+		PLATFORM_LD_OPTS=-Wl,--no-as-needed
 	else
 		EXT=
 		PLATFORM_OPTS=
-		PLATFORM_LD_OPTS=-lrt -Wl,--no-as-needed
+		PLATFORM_LD_OPTS=-pthread -lrt -Wl,--no-as-needed
 	endif
 endif
 
@@ -21,7 +25,7 @@ endif
 default: unittests$(EXT)
 
 unittests$(EXT): unittests.cpp ../../readerwriterqueue.h ../../readerwritercircularbuffer.h ../../atomicops.h ../common/simplethread.h ../common/simplethread.cpp minitest.h makefile
-	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) -pthread $(PLATFORM_LD_OPTS)
+	g++ $(PLATFORM_OPTS) -std=c++11 -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g unittests.cpp ../common/simplethread.cpp -o unittests$(EXT) $(PLATFORM_LD_OPTS)
 
 run: unittests$(EXT)
 	./unittests$(EXT)


### PR DESCRIPTION
This should make the library run on Haiku (https://www.haiku-os.org/). The PR uses Haiku's own API. As Haiku has pthreads support in a different directory, I changed the makefiles of the tests, which pass on x64 (I'll also check x32). They of course still work under linux