### PR TITLE
Improve MacOS version detection

### DIFF
--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -52,7 +52,7 @@
 #if defined (__APPLE__) && defined (__MACH__) && __cplusplus >= 201703L
 // This is required to find out what deployment target we are using
 #include <AvailabilityMacros.h>
-#if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || (defined(MAC_OS_X_VERSION_10_14) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14)
+#if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || !defined(MAC_OS_X_VERSION_10_14) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
 // C++17 new(size_t, align_val_t) is not backwards-compatible with older versions of macOS, so we can't support over-alignment in this case
 #define MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
 #endif

--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -51,8 +51,8 @@
 #ifndef MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
 #if defined (__APPLE__) && defined (__MACH__) && __cplusplus >= 201703L
 // This is required to find out what deployment target we are using
-#include <CoreFoundation/CoreFoundation.h>
-#if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
+#include <AvailabilityMacros.h>
+#if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || (defined(MAC_OS_X_VERSION_10_14) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14)
 // C++17 new(size_t, align_val_t) is not backwards-compatible with older versions of macOS, so we can't support over-alignment in this case
 #define MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
 #endif


### PR DESCRIPTION
This PR contains a few minor improvements for MacOS version detection:
- The MacOS version number defines are in AvailabilityMacros.h.
- As MAC_OS_X_VERSION_10_14 isn't defined on MacOS SDKs before the 10.14 SDK, it should be checked for being defined before using it.