### PR TITLE
Made Project Properly installable via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.9)
 set(CMAKE_CXX_STANDARD 11)  # don't need to specifiy
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(GNUInstallDirs)
+
 project(readerwriterqueue)
 
 add_library(readerwriterqueue INTERFACE)
@@ -25,9 +27,7 @@ set_target_properties(readerwriterqueue PROPERTIES EXPORT_NAME readerwriterqueue
 add_library(moodycamel::readerwriterqueue ALIAS readerwriterqueue)
 
 
-include(CMakePackageConfigHelpers)
 
-include(GNUInstallDirs)
 
 install(TARGETS readerwriterqueue
         EXPORT readerwriterqueue_Targets
@@ -54,6 +54,7 @@ install(EXPORT readerwriterqueue_Targets
         COMPONENT readerwriterqueue_Development
 )
 
+include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
         "${CMAKE_CURRENT_BINARY_DIR}/readerwriterqueueConfig.cmake"
         INSTALL_DESTINATION ${readerwriterqueue_INSTALL_CMAKEDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,143 @@
 cmake_minimum_required(VERSION 3.9)
-project(readerwriterqueue VERSION 1.0.0)
+set(CMAKE_CXX_STANDARD 11)  # don't need to specifiy
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(readerwriterqueue)
+
+add_library(readerwriterqueue INTERFACE)
+
+# This needs to be updated everytime the library tag version updates. The version is not 1.0.0, it's 1.0.6 according to tags.
+set_target_properties(readerwriterqueue PROPERTIES
+        SOVERSION 1
+        VERSION 1.0.6)
+
+#see this talk for why these changes need to be made https://www.youtube.com/watch?v=m0DwB4OvDXk
+
+target_include_directories(readerwriterqueue INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+
+set_target_properties(readerwriterqueue PROPERTIES EXPORT_NAME readerwriterqueue)
+
+# This is here to ensure parity with the install interface, but won't hide the previous target name.
+add_library(moodycamel::readerwriterqueue ALIAS readerwriterqueue)
+
+
+include(CMakePackageConfigHelpers)
 
 include(GNUInstallDirs)
 
-add_library(${PROJECT_NAME} INTERFACE)
+install(TARGETS readerwriterqueue
+        EXPORT readerwriterqueue_Targets
+        COMPONENT readerwriterqueue_Development
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        COMPONENT creaderwriterqueue_RunTime
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT readerwriterqueue_RunTIme
+        NAMELINK_COMPONENT readerwriterqueue_Development
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT readerwriterqueue_Development
+)
 
-target_include_directories(readerwriterqueue INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+set(readerwriterqueue_INSTALL_CMAKEDIR
+        ${CMAKE_INSTALL_DATADIR}/readerwriterqueue
+        CACHE STRING "Path to readerwriterqueue cmake files"
+)
 
-install(FILES atomicops.h readerwriterqueue.h readerwritercircularbuffer.h LICENSE.md
+install(EXPORT readerwriterqueue_Targets
+        DESTINATION ${readerwriterqueue_INSTALL_CMAKEDIR}
+        NAMESPACE moodycamel::
+        FILE readerwriterqueueTargets.cmake
+        COMPONENT readerwriterqueue_Development
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
+        "${CMAKE_CURRENT_BINARY_DIR}/readerwriterqueueConfig.cmake"
+        INSTALL_DESTINATION ${readerwriterqueue_INSTALL_CMAKEDIR}
+)
+
+
+get_target_property(readerwriterqueue_VERSION readerwriterqueue VERSION)
+
+write_basic_package_version_file(readerwriterqueueConfigVersion.cmake VERSION ${readerwriterqueue_VERSION} COMPATIBILITY SameMajorVersion)
+
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/readerwriterqueueConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/readerwriterqueueConfigVersion.cmake
+        DESTINATION ${readerwriterqueue_INSTALL_CMAKEDIR}
+)
+
+
+install(FILES
+        atomicops.h
+        readerwriterqueue.h
+        readerwritercircularbuffer.h
+        LICENSE.md
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+
+option(MOODYCAMEL_READERWRITERQUEUE_ENABLE_TESTS "Enables readerwriterqueue tests" OFF)
+
+if(${MOODYCAMEL_READERWRITERQUEUE_ENABLE_TESTS})
+
+    find_package(Threads REQUIRED)
+#    add_library(simple)
+    add_executable(unittests)
+    target_sources(unittests PRIVATE
+            tests/unittests/minitest.h
+            tests/unittests/unittests.cpp
+            tests/common/simplethread.h
+            tests/common/simplethread.cpp
+    )
+    target_include_directories(unittests PRIVATE
+            tests/unittests/)
+#    static.
+    set_property(TARGET unittests PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    # handles pthread and such.
+    target_link_libraries(unittests PRIVATE Threads::Threads)
+#    target_link_libraries(unittests PRIVATE readerwriterqueue)
+    target_compile_options(unittests
+            PRIVATE
+            $<$<CXX_COMPILER_ID:Clang>: -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g>
+            $<$<CXX_COMPILER_ID:GNU>:  -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g>
+#            /W4 is similar to -Wall, next are similar to -sign-conversion, /permissive- is similar to -Wpedantic.
+            $<$<CXX_COMPILER_ID:MSVC>: /W4 /w14287 /w14826 /permissive- /02 /DEBUG>
+    )
+    target_link_options(unittests
+            PRIVATE
+            $<$<CXX_COMPILER_ID:Clang>: -lrt -Wl,--no-as-needed>
+            $<$<CXX_COMPILER_ID:GNU>: -lrt -Wl,--no-as-needed>
+    )
+
+    #    add_library(simple)
+    add_executable(stabtest)
+    target_sources(stabtest PRIVATE
+            tests/stabtest/stabtest.cpp
+            tests/common/simplethread.h
+            tests/common/simplethread.cpp
+    )
+    target_include_directories(stabtest PRIVATE
+            tests/stabtest/)
+    #    static.
+    set_property(TARGET stabtest PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    # handles pthread and such.
+    target_link_libraries(stabtest PRIVATE Threads::Threads)
+    #    target_link_libraries(unittests PRIVATE readerwriterqueue)
+    target_compile_options(stabtest
+            PRIVATE
+            $<$<CXX_COMPILER_ID:Clang>: -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g>
+            $<$<CXX_COMPILER_ID:GNU>:  -Wsign-conversion -Wpedantic -Wall -DNDEBUG -O3 -g>
+            #            /W4 is similar to -Wall, next are similar to -sign-conversion, /permissive- is similar to -Wpedantic.
+            $<$<CXX_COMPILER_ID:MSVC>: /W4 /w14287 /w14826 /permissive- /02 /DEBUG>
+    )
+    target_link_options(stabtest
+            PRIVATE
+            $<$<CXX_COMPILER_ID:Clang>: -lrt -Wl,--no-as-needed>
+            $<$<CXX_COMPILER_ID:GNU>: -lrt -Wl,--no-as-needed>
+    )
+
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-set(CMAKE_CXX_STANDARD 11)  # don't need to specifiy
+set(CMAKE_CXX_STANDARD 11)  # don't need to specify manually per target anymore.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/readerwriterqueueTargets.cmake")
+# normally find_dependency macro dependencies, but there are none here.
+check_required_components(readerwriterqueue)


### PR DESCRIPTION
### Motivation: 

 Despite this library being header only, it is actually practically not drop in to any arbitrary project that is *not* an executable.   Today, both CMake and package managers have gotten to the point where its easier to use them than it is to maintain manually dropped header files, fetch content, or git submodules.  For a typical CMake library it is as easy to use header only as not header only, for example: 

```
    find_package(my_depedency)
    target_link_libraries(my_target PRIVATE namespace::my_depedency)
```

However the readerwriterqueue library requires me to *find the directory and then manually use the include dirs for this project*. 

```
    find_path(READERWRITERQUEUE_INCLUDE_DIRS "readerwriterqueue/atomicops.h")
    target_include_directories(my_target PRIVATE ${READERWRITERQUEUE_INCLUDE_DIRS})
```

This not only breaks IDE who use CMake source files to aid in quickly resolving names, but also requires me to *make my own target* if I wish to properly transitively include directories for all targets using this library instead of manually repeating the above process: 
 
```
    find_path(READERWRITERQUEUE_INCLUDE_DIRS "readerwriterqueue/atomicops.h")
    add_library(readerwriterqueue_proxy INTERFACE)
    target_include_directories(readerwriterqueue_proxy INTERFACE ${READERWRITERQUEUE_INCLUDE_DIRS})
   
    ...
    # then use it properly
    target_link_libraries(my_target PRIVATE readerwriterqueue_proxy )
    # or 
    target_link_libraries(my_target PUBLIC readerwriterqueue_proxy )
    # or 
    target_link_libraries(my_target INTERFACE readerwriterqueue_proxy )
```

This becomes even more important if cmake options/compile definitions *ever* get added to this library, I risk them leaking publicly or not being transitive if I don't create a proper target wrapper.  And not only do I have to do this, I have to *either repeat this for every project I use this library in, or I have to manage my own repo with this library, or create my own custom VCPKG registry*.   So it ends up being quite a lot of work just to deal with something that is supposed to be just drop in and use.   


Additionally the tests don't build out of the box.  Now these new cmake changes fix that.  I've also manually created a VCPKG port and verified this project works as an installable VCPKG project there. 


After this commit, after installing the package, using the library should look like this:

```
    find_package(readerwriterqueue)
    target_link_libraries(my_target PRIVATE moodycamel::readerwriterqueue)
```

Note add_subdirectory targets haven't been changed, only expanded so this works:

```
    add_subdirectory(external/readerwriterqueue)
    target_link_libraries(my_target PRIVATE moodycamel::readerwriterqueue)
```

as well as this

```
    add_subdirectory(external/readerwriterqueue)
    target_link_libraries(my_target PRIVATE readerwriterqueue)

```
### Commit message changes: 

Modified CMakeList.txt to be installable, now accessible through moodycamel::readerwriterqueue in both subdirectory and installed cmake project (didn't change targets that were already avaible, though projectect previously didn't work as an installable cmake project) also added test targets disabled by default configurable with variable psuedo namespaced 'MOODYCAMEL_READERWRITERQUEUE_ENABLE_TESTS', test targets are unittests and stabtest, completely ignores msvc project files and make files, so no need for those going forward, and though better practice would be to change the includes to be more target friendly (not use bespoke relative includes), I decided not to change that, so the previous way to build and run the test will *also* still work.  Added best pairing of MSVC equivalent compile commands I could find, and I verified all tests build and run correctly on Windows 11 with MSVC 14.38.33130


### Discussion:

Note I actually *don't* know the minimum required version of cmake for this, I need feedback on what this should be. Unlike other types of dependencies, upgrading cmake versions is *trivial* and expected to be done in the event of not having a late enough version no matter the system. Only the cmake executable itself is needed, and doesn't even need to be built for 99% of systems, and is generally compatible with any system that a previous version of cmake is on.  I'm using 3.26, this library states 3.9, but I'm not using the latest features, I might even be using 3.9 features, but there's no way for me to easily tell.  Though this whole question could be moot anyway, as it looks like using minimum versions in [CMake is somewhat of a farce](https://stackoverflow.com/questions/68058755/is-there-an-easy-way-to-find-what-the-minimum-required-version-for-cmake-should). 

