### PR TITLE
Place upper bound on required CMake version to avoid deprecation warning (Issue #165)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.9)
+# See https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487/2
+# for more on setting the minimum required version.
+
+cmake_minimum_required(VERSION 3.9...3.31.7)
 project(readerwriterqueue VERSION 1.0.7)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
See `https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487/2` for more on setting the minimum required version.
