### PR TITLE
Fix release fence ordering in inner_enqueue() to prevent size_approx() race on AArch64

### DIFF
--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -1,4 +1,4 @@
-// ©2013-2020 Cameron Desrochers.
+﻿// ©2013-2020 Cameron Desrochers.
 // Distributed under the simplified BSD license (see the license file that
 // should have come with this header).
 
@@ -619,6 +619,13 @@ private:
 				newBlock->tail = newBlock->localTail = 1;
 
 				newBlock->next = tailBlock_->next.load();
+
+				// Publish all writes to *newBlock before it becomes reachable via either
+				// tailBlock_->next (walked by size_approx() and other chain traversals)
+				// or tailBlock itself (used by try_dequeue). Without this fence, on
+				// weakly-ordered architectures (e.g. AArch64) a reader could observe the
+				// updated `next` pointer before seeing newBlock's initialized fields.
+				fence(memory_order_release);
 				tailBlock_->next = newBlock;
 
 				// Might be possible for the dequeue thread to see the new tailBlock->next
@@ -627,7 +634,6 @@ private:
 				// case where it could try to read the next is if it's already at the tailBlock,
 				// and it won't advance past tailBlock in any circumstance).
 
-				fence(memory_order_release);
 				tailBlock = newBlock;
 			}
 			else if (canAlloc == CannotAlloc) {

--- a/readerwriterqueue.h
+++ b/readerwriterqueue.h
@@ -620,20 +620,14 @@ private:
 
 				newBlock->next = tailBlock_->next.load();
 
-				// Publish all writes to *newBlock before it becomes reachable via either
-				// tailBlock_->next (walked by size_approx() and other chain traversals)
-				// or tailBlock itself (used by try_dequeue). Without this fence, on
-				// weakly-ordered architectures (e.g. AArch64) a reader could observe the
-				// updated `next` pointer before seeing newBlock's initialized fields.
+				// Publish all writes to *newBlock before it becomes reachable via
+				// tailBlock_->next.
 				fence(memory_order_release);
 				tailBlock_->next = newBlock;
 
-				// Might be possible for the dequeue thread to see the new tailBlock->next
-				// *without* seeing the new tailBlock value, but this is OK since it can't
-				// advance to the next block until tailBlock is set anyway (because the only
-				// case where it could try to read the next is if it's already at the tailBlock,
-				// and it won't advance past tailBlock in any circumstance).
-
+				// Ensure that readers observing the new tailBlock also observe the
+				// preceding publication of tailBlock_->next.
+				fence(memory_order_release);
 				tailBlock = newBlock;
 			}
 			else if (canAlloc == CannotAlloc) {


### PR DESCRIPTION
Fixes #171 

## What changed

Move `fence(memory_order_release)` in `inner_enqueue()`'s `CanAlloc`
branch so it precedes both writes that publish a newly allocated block
(`tailBlock_->next = newBlock` and `tailBlock = newBlock`), instead of
only the second one. See #171 for the full root-cause
analysis and repro.

Also expanded the comment at that call site to note that
`size_approx()` (and any other `Block::next`-chain traversal) depends
on this ordering too, not just `try_dequeue()`.

## Testing

- Reproduced the original crash on AArch64 with the existing
  `size_approx` stress test run in a loop (1000 iterations).
- Confirmed the crash no longer reproduces after the fix under the
  same loop (1000 iterations).
- Note: the existing `size_approx` stress test has other pre-existing
  assertion failures, unrelated to this change and not addressed here.